### PR TITLE
add intro paragraph to welcome view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,22 +1,22 @@
 :root {
-  --teal: #11A584;
-  --teal-dark: #109A7C;
-  --teal-light: #14BB97;
+  --teal: #11a584;
+  --teal-dark: #109a7c;
+  --teal-light: #14bb97;
 }
-
 
 .App {
   text-align: center;
   height: 100vh;
 }
 
-.Welcome, .SignUpDetails-back {
+.Welcome,
+.SignUpDetails-back {
   color: white;
   height: inherit;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  background: linear-gradient( var(--teal-light), var(--teal-dark));
+  background: linear-gradient(var(--teal-light), var(--teal-dark));
 }
 
 .Welcome img {
@@ -60,34 +60,37 @@
 header {
   justify-self: start;
 }
-header, footer {
+header,
+footer {
   padding: 1em 0.5em;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background-color: var(--teal);
-  color: white
+  color: white;
 }
 footer {
   justify-self: end;
 }
 
-button, .button {
+button,
+.button {
   background-color: var(--teal);
   padding: 0.5em 1em;
   border-radius: 5px;
   border: none;
   box-shadow: 1px 1px 3px black;
-  color: white
+  color: white;
 }
 
-button:hover, .button:hover {
+button:hover,
+.button:hover {
   background-color: var(--teal-dark);
 }
-button:active, .button:active {
+button:active,
+.button:active {
   background-color: var(--teal-light);
   box-shadow: 0 0 2px black;
-
 }
 
 .nav-button {
@@ -189,15 +192,16 @@ form.edit-form {
   height: 85vh;
   width: 80%;
   padding: 1em 0;
-  margin: 0 auto 2em auto
+  margin: 0 auto 2em auto;
 }
 
-form.edit-form, div.section {
-  display: flex; 
+form.edit-form,
+div.section {
+  display: flex;
   flex-direction: column;
 }
 
-.edit-form label{
+.edit-form label {
   margin-top: 1.5em;
 }
 
@@ -232,4 +236,11 @@ div.section {
   height: 50px;
   object-fit: cover;
   border-radius: 90px;
+}
+
+.intro-paragraph {
+  max-width: 500px;
+  text-align: left;
+  margin: 0 auto;
+  padding: 0 1rem;
 }

--- a/src/components/LogoSplash.js
+++ b/src/components/LogoSplash.js
@@ -1,14 +1,19 @@
 import React from "react";
 
-const LogoSplash = () => {
-    return (
-        <div>
-            <h1>Session 0</h1>
-            <img className="logo-img" src="android-chrome-192x192.png" alt="d10 logo"/>
-            <h2>Find Players - Find Games</h2>
-	        <h3>Adventure Awaits!</h3>
-        </div>
-    )
-}
+const LogoSplash = (props) => {
+  return (
+    <div>
+      <h1>Session 0</h1>
+      <img
+        className="logo-img"
+        src="android-chrome-192x192.png"
+        alt="d10 logo"
+      />
+      <h2>Find Players - Find Games</h2>
+      <h3>Adventure Awaits!</h3>
+      <p className="intro-paragraph">{props.introParagraph}</p>
+    </div>
+  );
+};
 
-export default LogoSplash
+export default LogoSplash;

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -4,20 +4,20 @@ import { Link } from "react-router-dom";
 import LogoSplash from "../components/LogoSplash";
 
 const Welcome = () => {
-    return(
+  return (
     <div className="Welcome">
-        <LogoSplash />
-		<div className="onboarding-options">
-			<Link to="/login">
-				<button>Login</button>
-			</Link>
-			<h3>or</h3>
-			<Link to="/signup">
-				<button>Sign Up</button>
-			</Link>
-		</div>
+      <LogoSplash introParagraph="Session 0 is a prototype social groups app that allows TTRPG players to find groups to join and run. The app is built with a FaunaDB database and a React frontend. Features include user authentication and relational data driven&nbsp;pages." />
+      <div className="onboarding-options">
+        <Link to="/login">
+          <button>Login</button>
+        </Link>
+        <h3>or</h3>
+        <Link to="/signup">
+          <button>Sign Up</button>
+        </Link>
+      </div>
     </div>
-    )
-}
+  );
+};
 
-export default Welcome
+export default Welcome;


### PR DESCRIPTION
I thought it might be nice for the welcome page to have a brief description of the service to help users decide if they want to sign up. 

I added a prop for the Logo Splash component that displays a description paragraph at the bottom of the component. 

A default value should probably be set for this prop to increase its resilience in case the Logo Splash is used somewhere without that prop, but at the moment it works without a default. 

Better yet, it might be nice to have the description someone other than hard coded into to the welcome.js page to separate concerns a bit, but this works as a quick solution.